### PR TITLE
Fix notification bug and missing property

### DIFF
--- a/Cron/FeedGeneration.php
+++ b/Cron/FeedGeneration.php
@@ -151,7 +151,7 @@ class FeedGeneration
             $this->_notificationsList[] = $msg;
 
             // notifications
-            if (!empty($this->_notificationsList))
+            if (!empty($this->_notificationsList)) {
                 $ret = $this->_notifications->sendNotifications($this->_notificationsList, $store);
                 if (!$ret["success"]) {
                     // deleting lock file
@@ -159,6 +159,7 @@ class FeedGeneration
                     $this->_logger->error($ret["message"]);
                     return false;
                 }
+            }
         }
 
         // deleting lock file

--- a/Service/DynamicPrice.php
+++ b/Service/DynamicPrice.php
@@ -61,6 +61,11 @@ class DynamicPrice implements DynamicPriceInterface
     private SerializerInterface $serializer;
 
     /**
+     * @var TaxHelper
+     */
+    private TaxHelper $taxHelper;
+
+    /**
      * @param ProductRepositoryInterface $productRepository
      * @param PriceCurrencyInterface $priceCurrency
      * @param Logger $logger


### PR DESCRIPTION
## Summary
- fix logic for sending notifications after feed generation
- declare TaxHelper property in DynamicPrice service

## Testing
- `php -l Cron/FeedGeneration.php`
- `php -l Service/DynamicPrice.php`
- `find . -name '*.php' | xargs -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68775e1d75ac8329920f1d58f5ee0d27