### PR TITLE
chore: bump module version to 1.8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "accelasearch/magento2",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "N/A",
   "type": "magento2-module",
   "require": {


### PR DESCRIPTION
## Summary
- update module version to 1.8.5

## Testing
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_6894c05dd6748329a35c6c2957017b22