### PR TITLE
feat: add php 8.4 compatibility

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -17,6 +17,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -35,7 +36,7 @@ class Data extends AbstractHelper
     const SELLING_PRICE_PATH = 'accelasearch_search/dynamicprice/selling_price';
     const SELLING_PRICE_TYPE = 'accelasearch_search/dynamicprice/selling_price_type';
 
-    public $dbmage_read;
+    public ?AdapterInterface $dbmage_read = null;
 
     /**
      * @var StoreManagerInterface

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "description": "N/A",
   "type": "magento2-module",
   "require": {
+    "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
     "magento/framework": "*"
   },
   "license": [


### PR DESCRIPTION
## Summary
- add explicit PHP 8.4 requirement
- type DB adapter property

## Testing
- `composer validate`
- `php -l Helper/Data.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c041c6108329b7e532724aa64067